### PR TITLE
Reorganize api

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -10,8 +10,8 @@ use crate::command::Register;
 use crate::pool::{ImageData, Pool};
 use crate::program::{
     BindGroupDescriptor, BindGroupLayoutDescriptor, BindingResource, Buffer, BufferDescriptor,
-    BufferDescriptorInit, BufferInitContent, BufferUsage, ColorAttachmentDescriptor, DeviceBuffer,
-    DeviceTexture, FragmentState, Function, ImageBufferAssignment, ImageBufferPlan,
+    BufferDescriptorInit, BufferInitContent, BufferUsage, Capabilities, ColorAttachmentDescriptor,
+    DeviceBuffer, DeviceTexture, FragmentState, Function, ImageBufferAssignment, ImageBufferPlan,
     ImageDescriptor, ImagePoolPlan, LaunchError, Low, PipelineLayoutDescriptor, PrimitiveState,
     RenderPassDescriptor, RenderPipelineDescriptor, SamplerDescriptor, ShaderDescriptor,
     StagingDescriptor, Texture, TextureDescriptor, TextureUsage, TextureViewDescriptor,
@@ -225,10 +225,11 @@ impl<I: ExtendOne<Low>> Encoder<I> {
     /// Tell the encoder which commands are natively supported.
     /// Some features require GPU support. At this point we decide if our request has succeeded and
     /// we might poly-fill it with a compute shader or something similar.
-    pub(crate) fn enable_capabilities(&mut self, device: &wgpu::Device) {
-        // currently no feature selection..
-        let _ = device.features();
-        let _ = device.limits();
+    pub(crate) fn enable_capabilities(&mut self, caps: &Capabilities) {
+        // FIXME: currently nothing uses features or limits.
+        // Which is wrong, we can use features to skip some staging. We might also have some
+        // slightly different shader features such as using push constants in some cases?
+        let _ = caps;
     }
 
     pub(crate) fn set_buffer_plan(&mut self, plan: &ImageBufferPlan) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub mod buffer;
 pub mod command;
 mod encoder;
 pub mod pool;
-mod program;
+pub mod program;
 pub mod run;
 mod shaders;
 mod util;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -3,6 +3,7 @@ use slotmap::{DefaultKey, SlotMap};
 use wgpu::{Buffer, Texture};
 
 use crate::buffer::{BufferLayout, Color, Descriptor, ImageBuffer, Texel};
+use crate::{program, run::Gpu};
 
 /// Holds a number of image buffers, their descriptors and meta data.
 ///
@@ -10,10 +11,14 @@ use crate::buffer::{BufferLayout, Color, Descriptor, ImageBuffer, Texel};
 #[derive(Default)]
 pub struct Pool {
     items: SlotMap<DefaultKey, Image>,
+    devices: SlotMap<DefaultKey, Gpu>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct PoolKey(DefaultKey);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct GpuKey(DefaultKey);
 
 /// A view on an image inside the pool.
 pub struct PoolImage<'pool> {
@@ -58,9 +63,19 @@ pub(crate) struct ImageMeta {
 pub(crate) enum ImageData {
     Host(ImageBuffer),
     /// The data lives in a generic buffer.
-    Gpu(Buffer, BufferLayout),
+    /// This buffer should be associated to one of the GPU devices.
+    Gpu {
+        buffer: Buffer,
+        layout: BufferLayout,
+        gpu: DefaultKey,
+    },
     /// The data lives in a texture buffer on the device.
-    GpuTexture(Texture, BufferLayout),
+    /// This buffer should be associated to one of the GPU devices.
+    GpuTexture {
+        texture: Texture,
+        layout: BufferLayout,
+        gpu: DefaultKey,
+    },
     /// The image data will be provided by the caller.
     /// Such data can only be used in operations that do not keep a reference, e.g. it is not
     /// possible to create a mere view.
@@ -71,6 +86,42 @@ impl Pool {
     /// Create an empty pool.
     pub fn new() -> Self {
         Pool::default()
+    }
+
+    /// Create a device given a descriptor of requested features.
+    ///
+    /// This will request a device from the adaptor according to the provided descriptor and then
+    /// directly insert it into the pool. Then it returns the unique key for that newly created
+    /// device and queue.
+    pub fn request_device(
+        &mut self,
+        adapter: &wgpu::Adapter,
+        device: wgpu::DeviceDescriptor,
+    ) -> Result<GpuKey, wgpu::RequestDeviceError> {
+        let request = adapter.request_device(&device, None);
+        let (device, queue) = program::block_on(request, None)?;
+        let gpu_key = self.devices.insert(Gpu { device, queue });
+        Ok(GpuKey(gpu_key))
+    }
+
+    pub(crate) fn reinsert_device(&mut self, gpu: Gpu) -> GpuKey {
+        GpuKey(self.devices.insert(gpu))
+    }
+
+    pub(crate) fn select_device(&mut self, caps: &program::Capabilities)
+        -> Option<(GpuKey, Gpu)>
+    {
+        let key = self.select_device_key(caps)?;
+        let device = self.devices.remove(key).unwrap();
+        Some((GpuKey(key), device))
+    }
+
+    fn select_device_key(&mut self, _: &program::Capabilities) -> Option<DefaultKey> {
+        for (key, _) in &self.devices {
+            // FIXME: check device against capabilities.
+            return Some(key)
+        }
+        None
     }
 
     /// Get a mutable handle of an image in the pool.
@@ -317,8 +368,8 @@ impl ImageData {
     pub(crate) fn layout(&self) -> &BufferLayout {
         match self {
             ImageData::Host(canvas) => canvas.layout(),
-            ImageData::Gpu(_, layout) => layout,
-            ImageData::GpuTexture(_, layout) => layout,
+            ImageData::Gpu { layout, .. } => layout,
+            ImageData::GpuTexture{ layout, .. } => layout,
             ImageData::LateBound(layout) => layout,
         }
     }
@@ -338,8 +389,8 @@ impl fmt::Debug for ImageData {
         match self {
             ImageData::LateBound(layout) => write!(f, "ImageData::LayoutBound({:?})", layout),
             ImageData::Host(buffer) => write!(f, "ImageData::Host({:?})", buffer.layout()),
-            ImageData::GpuTexture(_, layout) => write!(f, "ImageData::GpuTexture({:?})", layout),
-            ImageData::Gpu(_, layout) => write!(f, "ImageData::GpuBuffer({:?})", layout),
+            ImageData::GpuTexture { layout, .. } => write!(f, "ImageData::GpuTexture({:?})", layout),
+            ImageData::Gpu { layout, .. } => write!(f, "ImageData::GpuBuffer({:?})", layout),
         }
     }
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -111,7 +111,7 @@ impl Pool {
         Ok(GpuKey(gpu_key))
     }
 
-    pub fn iter_devices(&self) -> impl Iterator<Item=&'_ wgpu::Device> {
+    pub fn iter_devices(&self) -> impl Iterator<Item = &'_ wgpu::Device> {
         self.devices.iter().map(|kv| &kv.1.device)
     }
 
@@ -119,9 +119,7 @@ impl Pool {
         GpuKey(self.devices.insert(gpu))
     }
 
-    pub(crate) fn select_device(&mut self, caps: &program::Capabilities)
-        -> Option<(GpuKey, Gpu)>
-    {
+    pub(crate) fn select_device(&mut self, caps: &program::Capabilities) -> Option<(GpuKey, Gpu)> {
         let key = self.select_device_key(caps)?;
         let device = self.devices.remove(key).unwrap();
         Some((GpuKey(key), device))
@@ -130,7 +128,7 @@ impl Pool {
     fn select_device_key(&mut self, _: &program::Capabilities) -> Option<DefaultKey> {
         for (key, _) in &self.devices {
             // FIXME: check device against capabilities.
-            return Some(key)
+            return Some(key);
         }
         None
     }
@@ -234,7 +232,7 @@ impl ImageData {
         match self {
             ImageData::Host(canvas) => canvas.layout(),
             ImageData::Gpu { layout, .. } => layout,
-            ImageData::GpuTexture{ layout, .. } => layout,
+            ImageData::GpuTexture { layout, .. } => layout,
             ImageData::LateBound(layout) => layout,
         }
     }
@@ -411,7 +409,9 @@ impl fmt::Debug for ImageData {
         match self {
             ImageData::LateBound(layout) => write!(f, "ImageData::LayoutBound({:?})", layout),
             ImageData::Host(buffer) => write!(f, "ImageData::Host({:?})", buffer.layout()),
-            ImageData::GpuTexture { layout, .. } => write!(f, "ImageData::GpuTexture({:?})", layout),
+            ImageData::GpuTexture { layout, .. } => {
+                write!(f, "ImageData::GpuTexture({:?})", layout)
+            }
             ImageData::Gpu { layout, .. } => write!(f, "ImageData::GpuBuffer({:?})", layout),
         }
     }

--- a/src/program.rs
+++ b/src/program.rs
@@ -618,9 +618,10 @@ impl ImagePoolPlan {
 
 impl Program {
     /// Choose an applicable adapter from one of the presented ones.
-    pub fn choose_adapter(&self, from: impl Iterator<Item = wgpu::Adapter>)
-        -> Result<wgpu::Adapter, MismatchError>
-    {
+    pub fn choose_adapter(
+        &self,
+        from: impl Iterator<Item = wgpu::Adapter>,
+    ) -> Result<wgpu::Adapter, MismatchError> {
         Program::minimum_adapter(from)
     }
 
@@ -727,7 +728,11 @@ impl Program {
         })
     }
 
-    fn lower_to_impl(&self, capabilities: &Capabilities, pool_plan: Option<&ImagePoolPlan>) -> Result<Encoder, LaunchError> {
+    fn lower_to_impl(
+        &self,
+        capabilities: &Capabilities,
+        pool_plan: Option<&ImagePoolPlan>,
+    ) -> Result<Encoder, LaunchError> {
         let mut encoder = Encoder::default();
         encoder.enable_capabilities(&capabilities);
 
@@ -900,7 +905,9 @@ impl Launcher<'_> {
 
         let capabilities = Capabilities::from(&device);
 
-        let mut encoder = self.program.lower_to_impl(&capabilities, Some(&self.pool_plan))?;
+        let mut encoder = self
+            .program
+            .lower_to_impl(&capabilities, Some(&self.pool_plan))?;
         let mut buffers = self.binds;
         encoder.extract_buffers(&mut buffers, &mut self.pool)?;
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -171,10 +171,15 @@ impl Executable {
         }
     }
 
-    pub fn bind(&mut self, reg: Register, mut pool_img: PoolImageMut<'_>)
-        -> Result<(), StartError>
-    {
-        let &idx = self.io_map.inputs.get(&reg)
+    pub fn bind(
+        &mut self,
+        reg: Register,
+        mut pool_img: PoolImageMut<'_>,
+    ) -> Result<(), StartError> {
+        let &idx = self
+            .io_map
+            .inputs
+            .get(&reg)
             .ok_or_else(|| StartError::InternalCommandError(line!()))?;
 
         let image = &mut self.buffers[idx];
@@ -196,7 +201,8 @@ impl Executable {
     }
 
     pub fn launch(mut self) -> Result<Execution, StartError> {
-        let gpu = self.gpu
+        let gpu = self
+            .gpu
             .ok_or_else(|| StartError::InternalCommandError(line!()))?;
 
         eprintln!("{:?}", &self.io_map.inputs);

--- a/tests/blend.rs
+++ b/tests/blend.rs
@@ -1,7 +1,7 @@
 use stealth_paint::buffer::{self, Descriptor, Whitepoint};
 use stealth_paint::command::{self, CommandBuffer, Rectangle, Register};
 use stealth_paint::pool::{Pool, PoolKey};
-use stealth_paint::run::Retire;
+use stealth_paint::{program::Program, run::Retire};
 
 #[path = "util.rs"]
 mod util;
@@ -17,6 +17,8 @@ fn integration() {
     const ANY: wgpu::BackendBit = wgpu::BackendBit::all();
     // FIXME: this drop SEGFAULTs for me...
     let instance = core::mem::ManuallyDrop::new(wgpu::Instance::new(ANY));
+    let adapter = Program::minimum_adapter(instance.enumerate_adapters(ANY))
+        .expect("to get an adapter");
 
     let background = image::open(BACKGROUND).expect("Background image opened");
     let foreground = image::open(FOREGROUND).expect("Background image opened");
@@ -31,6 +33,9 @@ fn integration() {
         let entry = pool.insert_srgb(&foreground);
         (entry.key(), entry.descriptor())
     };
+
+    pool.request_device(&adapter, wgpu::DeviceDescriptor::default())
+        .expect("to get a device");
 
     run_blending(
         &mut pool,

--- a/tests/direct.rs
+++ b/tests/direct.rs
@@ -1,0 +1,93 @@
+//! This test ensures that the direct `Program::launch` interface can be used.
+use stealth_paint::buffer::Descriptor;
+use stealth_paint::command::{CommandBuffer, Rectangle};
+use stealth_paint::pool::{Pool, PoolKey};
+
+#[path = "util.rs"]
+mod util;
+
+const BACKGROUND: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/input/background.png");
+const FOREGROUND: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/input/foreground.png");
+
+#[test]
+fn standard() {
+    env_logger::init();
+
+    const ANY: wgpu::BackendBit = wgpu::BackendBit::all();
+    // FIXME: this drop SEGFAULTs for me...
+    let instance = core::mem::ManuallyDrop::new(wgpu::Instance::new(ANY));
+
+    let background = image::open(BACKGROUND).expect("Background image opened");
+    let foreground = image::open(FOREGROUND).expect("Background image opened");
+
+    let mut pool = Pool::new();
+    let pool_background = {
+        let entry = pool.insert_srgb(&background);
+        (entry.key(), entry.descriptor())
+    };
+
+    let pool_foreground = {
+        let entry = pool.insert_srgb(&foreground);
+        (entry.key(), entry.descriptor())
+    };
+
+    run_blending(
+        &mut pool,
+        instance.enumerate_adapters(ANY),
+        pool_foreground.clone(),
+        pool_background.clone(),
+    );
+}
+
+fn run_blending(
+    pool: &mut Pool,
+    adapters: impl Iterator<Item = wgpu::Adapter>,
+    (fg_key, foreground): (PoolKey, Descriptor),
+    (bg_key, background): (PoolKey, Descriptor),
+) {
+    let mut commands = CommandBuffer::default();
+
+    let placement = Rectangle {
+        x: 0,
+        y: 0,
+        max_x: foreground.layout.width(),
+        max_y: foreground.layout.height(),
+    };
+
+    // Describe the pipeline:
+    // 0: in (background)
+    // 1: in (foreground)
+    // 2: inscribe(0, placement, 1)
+    // 3: out(2)
+    let background = commands.input(background).unwrap();
+    let foreground = commands.input(foreground).unwrap();
+
+    let result = commands
+        .inscribe(background, placement, foreground)
+        .expect("Valid to inscribe");
+
+    let (output, _outformat) = commands.output(result).expect("Valid for output");
+
+    let plan = commands.compile().expect("Could build command buffer");
+    let adapter = plan
+        .choose_adapter(adapters)
+        .expect("Did not find any adapter for executing the blend operation");
+
+    let mut execution = plan
+        .launch(pool)
+        .bind(background, bg_key)
+        .unwrap()
+        .bind(foreground, fg_key)
+        .unwrap()
+        .launch(&adapter)
+        .expect("Launching failed");
+
+    while execution.is_running() {
+        let _wait_point = execution.step().expect("Shouldn't fail but");
+    }
+
+    let mut retire = execution.retire_gracefully(pool);
+
+    let image = retire.output(output).expect("A valid image output");
+    util::assert_reference(image, "composed.png.crc");
+}


### PR DESCRIPTION
This refactors the launch API such that we can effectively reuse a device, by putting it into a `Pool`. All compilation and instruction lowering steps are now done against the `Capabilities` (features and limits) of the device instead of an actual instantation. The same holds for pool images which need no longer be immediately available during low instruction encoding. 

This brings our full test suite (11 compositions including Oklab transformation, chromatic adaptation, affine transformation etc.) to a mere `0.36`. This _still_ includes IO for decoding the initial images and a bunch of other stuff (inflate+CRC takes 8–12% of the time :eyes:. Should we look into doing that on the GPU as well)